### PR TITLE
Fix identity DTO alignment and seeding configuration

### DIFF
--- a/CODE_REVIEW.md
+++ b/CODE_REVIEW.md
@@ -1,0 +1,24 @@
+# Code Review Findings
+
+## Critical functional gaps
+- The mobile client expects a `POST /api/v1/auth/sign-up` endpoint, but `AuthController` is empty, so sign-up always fails with a 404/405 despite the client calling it.【F:app/NavQurt.Server.App/Services/AuthApi.cs†L22-L30】【F:src/NavQurt.Server.Web/Controllers/AuthController.cs†L5-L10】
+- The client also calls `GET /api/v1/me` to fetch the current profile, yet `UsersController` exposes no actions, leaving the feature unimplemented.【F:app/NavQurt.Server.App/Services/AuthApi.cs†L76-L83】【F:src/NavQurt.Server.Web/Controllers/UsersController.cs†L5-L10】
+
+## Data model and DTO issues
+- Application DTOs use GUID identifiers (`SignUpResponse`, `AssignRoleRequest`), but `AppUser` inherits from `IdentityUser` with a string key. This mismatch will break serialization/mapping once those DTOs are used.【F:src/NavQurt.Server.Application/Dto/Auth.cs†L3-L5】【F:src/NavQurt.Server.Core/Entities/AppUser.cs†L5-L12】
+- `SignUpRequest` defines properties `Firstname`/`Lastname` (lowercase "n"), which do not match the camel-cased `FirstName`/`LastName` payload emitted by the MAUI client. Model binding would therefore drop those values when the endpoint is implemented.【F:src/NavQurt.Server.Application/Dto/Auth.cs†L3】【F:app/NavQurt.Server.App/Services/AuthApi.cs†L22-L29】
+- The generic repository contracts force `IEntity<int>` for most operations, preventing reuse with core identity entities (`AppUser` uses `string`, OpenIddict entities use `long`). Any attempt to reuse the abstractions for those types will fail at compile time.【F:src/NavQurt.Server.Core/Persistence/IRepository.cs†L19-L102】【F:src/NavQurt.Server.Core/Entities/AppUser.cs†L5-L12】【F:src/NavQurt.Server.Core/Entities/OpenIdApplication.cs†L5-L7】
+
+## Infrastructure and seeding
+- `IdentitySeeder` looks up an existing admin account by user name "admin" but creates it with the user name "SuperAdmin". This causes the lookup to fail on every run and the second seeding attempt to throw because the unique email already exists.【F:src/NavQurt.Server.Infrastructure/Seed/IdentitySeeder.cs†L22-L39】
+- The same seeder hardcodes a production-like password (`SuperAdmin@123`). Credentials committed to source control present a security risk and should be moved to configuration or secret management.【F:src/NavQurt.Server.Infrastructure/Seed/IdentitySeeder.cs†L37】
+- `MainDbContext` applies configuration from `typeof(AppDbContext).Assembly`, which is misleading at best and fragile if `AppDbContext` is removed; the intent is presumably to use the current context type.【F:src/NavQurt.Server.Infrastructure/Data/MainDbContext.cs†L24-L31】【F:src/NavQurt.Server.Infrastructure/Data/AppDbContext.cs†L5-L13】
+- Only `MainDbContext` is registered in DI, yet `CompanyRepository` depends on `AppDbContext`. Without adding `AppDbContext` to the service collection, that repository cannot be resolved.【F:src/NavQurt.Server.Web/Extensions/DbContextExtensions.cs†L8-L16】【F:src/NavQurt.Server.Infrastructure/Persistence/CompanyRepository.cs†L10-L71】
+
+## Maintainability concerns
+- Nearly every C# file contains a UTF-8 BOM character (`﻿`) at the beginning (visible as `﻿` in diffs). This pollutes diffs and can break tooling; consider normalizing the encoding via `.editorconfig` or repository settings.【F:src/NavQurt.Server.Web/Controllers/AuthController.cs†L1-L10】【F:src/NavQurt.Server.Infrastructure/Persistence/GenericRepository.cs†L1-L75】
+- README.md only contains the project title without setup or usage instructions, which makes onboarding difficult.【F:README.md†L1】
+
+## Tooling status
+- `dotnet build` could not be executed in the review environment because the .NET SDK is not installed, so runtime issues may still exist.【05cf64†L1-L3】
+

--- a/README.md
+++ b/README.md
@@ -1,1 +1,55 @@
-# NavQurtDemoSolution
+# NavQurt Demo Solution
+
+## Overview
+NavQurt is split into a .NET multi-project backend hosted in `src/` and a MAUI client hosted in `app/`. The server exposes authentication endpoints backed by ASP.NET Core Identity and OpenIddict, while the client exercises those endpoints for sign-up and token management scenarios.
+
+## Prerequisites
+- .NET 7 SDK or later
+- PostgreSQL 14 or later
+- Node.js 18+ (for building frontend assets, if any project requires it)
+
+## Configuration
+Connection strings and seed credentials are read from configuration (appsettings, environment variables, or user secrets). At a minimum, the following keys must be provided:
+
+```json
+{
+  "ConnectionStrings": {
+    "Default": "Host=localhost;Database=navqurt;Username=postgres;Password=postgres"
+  },
+  "Seed": {
+    "AdminUserName": "SuperAdmin",
+    "AdminEmail": "superadmin@qurt.local",
+    "AdminPassword": "<set a secure password>",
+    "AdminPhone": "+998900000000"
+  }
+}
+```
+
+The seeder will skip creating the administrator account if `Seed:AdminPassword` is not supplied.
+
+Optional overrides are available for `Seed:AdminFirstName` and `Seed:AdminLastName`.
+
+## Database Setup
+1. Create the database defined in the `ConnectionStrings:Default` setting.
+2. Apply the Entity Framework Core migrations:
+   ```bash
+   dotnet ef database update --project src/NavQurt.Server.Infrastructure --startup-project src/NavQurt.Server.Web
+   ```
+3. Run the web project once to execute the identity seeder.
+
+## Running the Server
+```bash
+dotnet run --project src/NavQurt.Server.Web
+```
+The API listens on the URLs defined in the project's `launchSettings.json` or the `ASPNETCORE_URLS` environment variable.
+
+## Running the MAUI Client
+```bash
+dotnet build app/NavQurt.Server.App
+```
+Additional platform-specific commands may be required (Android/iOS emulators, Windows packaging, etc.). Refer to the official MAUI documentation for details.
+
+## Troubleshooting
+- Ensure PostgreSQL is running and reachable via the configured connection string.
+- Confirm the admin password is supplied before running the seeder; otherwise the initial admin account will not be created.
+- Review application logs for seeding warnings or errors.

--- a/src/NavQurt.Server.Application/Dto/Auth.cs
+++ b/src/NavQurt.Server.Application/Dto/Auth.cs
@@ -1,6 +1,6 @@
-﻿namespace NavQurt.Server.Application.Dto
+namespace NavQurt.Server.Application.Dto
 {
-    public record SignUpRequest(string UserName, string Password, string? Firstname, string Lastname, string? Email, string? Phone);
-    public record SignUpResponse(Guid UserId, string UserName, string? Email, string? Phone, string? FullName);
-    public record AssignRoleRequest(Guid UserId, string RoleName);
+    public record SignUpRequest(string UserName, string Password, string? FirstName, string? LastName, string? Email, string? Phone);
+    public record SignUpResponse(string UserId, string UserName, string? Email, string? Phone, string? FullName);
+    public record AssignRoleRequest(string UserId, string RoleName);
 }

--- a/src/NavQurt.Server.Core/Persistence/IRepository.cs
+++ b/src/NavQurt.Server.Core/Persistence/IRepository.cs
@@ -1,4 +1,4 @@
-﻿using NavQurt.Server.Core.Entities;
+using System.Collections.Generic;
 using System.Linq.Expressions;
 
 namespace NavQurt.Server.Core.Persistence
@@ -14,25 +14,25 @@ namespace NavQurt.Server.Core.Persistence
         /// Asynchronously counts number of entities.
         /// </summary>
         /// <param name="predicate">Predicate to filter query</param>
-        /// <typeparam name="TEntity">Class that implements the <see cref="IEntity{TKey}"/> interface</typeparam>
+        /// <typeparam name="TEntity">Entity type</typeparam>
         /// <returns>Number of elements that satisfies the specified condition</returns>
         Task<int> CountAsync<TEntity>(Expression<Func<TEntity, bool>>? predicate = default)
-            where TEntity : class, IEntity<int>;
+            where TEntity : class;
 
         /// <summary>
         /// Asynchronously computes the sum of a sequence of values
         /// </summary>
         /// <param name="selector">A projection function to apply to each element</param>
-        /// <typeparam name="TEntity">Class that implements the <see cref="IEntity{TKey}"/> interface</typeparam>
+        /// <typeparam name="TEntity">Entity type</typeparam>
         /// <returns>The sum of the projected values</returns>
-        Task<decimal> SumAsync<TEntity>(Expression<Func<TEntity, decimal>> selector, Expression<Func<TEntity, bool>> predicate = default)
-            where TEntity : class, IEntity<int>;
+        Task<decimal> SumAsync<TEntity>(Expression<Func<TEntity, decimal>> selector, Expression<Func<TEntity, bool>>? predicate = default)
+            where TEntity : class;
 
         /// <summary>
         /// Gets an entity object by ID.
         /// </summary>
         /// <param name="id">Entity primary key</param>
-        /// <typeparam name="TEntity">Class that implements the <see cref="IEntity{TKey}"/> interface</typeparam>
+        /// <typeparam name="TEntity">Entity type</typeparam>
         /// <returns>Entity object</returns>
         Task<TEntity?> GetAsync<TEntity>(object? id)
             where TEntity : class;
@@ -41,38 +41,38 @@ namespace NavQurt.Server.Core.Persistence
         /// Gets an entity object filtered by predicate.
         /// </summary>
         /// <param name="predicate">Predicate to filter query</param>
-        /// <typeparam name="TEntity">Class that implements the <see cref="IEntity{TKey}"/> interface</typeparam>
+        /// <typeparam name="TEntity">Entity type</typeparam>
         /// <returns>Entity object</returns>
         Task<TEntity?> GetAsync<TEntity>(Expression<Func<TEntity, bool>> predicate)
-            where TEntity : class, IEntity<int>;
+            where TEntity : class;
 
         /// <summary>
         /// Gets a list of the entity objects
         /// </summary>
         /// <param name="predicate">Predicate to filter query</param>
-        /// <typeparam name="TEntity">Class that implements the <see cref="IEntity{TKey}"/> interface</typeparam>
+        /// <typeparam name="TEntity">Entity type</typeparam>
         /// <returns>List of entity objects</returns>
         Task<List<TEntity>> GetListAsync<TEntity>(Expression<Func<TEntity, bool>>? predicate = default)
-            where TEntity : class, IEntity<int>;
+            where TEntity : class;
 
         /// <summary>
         /// Gets a dictionary of the entities and specified keys.
         /// </summary>
         /// <param name="keySelector">Key selector</param>
         /// <param name="predicate">Predicate to filter query</param>
-        /// <typeparam name="TEntity">Class that implements the <see cref="IEntity{TKey}"/> interface</typeparam>
-        /// <typeparam name="TKey">Key</typeparam>
+        /// <typeparam name="TEntity">Entity type</typeparam>
+        /// <typeparam name="TKey">Dictionary key type</typeparam>
         Task<Dictionary<TKey, TEntity>> GetDictionaryAsync<TKey, TEntity>(
             Func<TEntity, TKey> keySelector,
             Expression<Func<TEntity, bool>>? predicate = default)
-            where TEntity : class, IEntity<int>
+            where TEntity : class
             where TKey : notnull;
 
         /// <summary>
         /// Gets IQueryable entity objects.
         /// </summary>
         /// <param name="predicate">Predicate to filter query</param>
-        /// <typeparam name="TEntity">Class that implements the <see cref="IEntity{TKey}"/> interface</typeparam>
+        /// <typeparam name="TEntity">Entity type</typeparam>
         /// <returns>IQueryable of entity objects</returns>
         IQueryable<TEntity> Query<TEntity>(Expression<Func<TEntity, bool>>? predicate = default)
             where TEntity : class;
@@ -81,24 +81,24 @@ namespace NavQurt.Server.Core.Persistence
         /// Adds new entry to database.
         /// </summary>
         /// <param name="entity">Entity object</param>
-        /// <typeparam name="TEntity">Class that implements the <see cref="IEntity{TKey}"/> interface</typeparam>
+        /// <typeparam name="TEntity">Entity type</typeparam>
         Task AddAsync<TEntity>(TEntity entity)
-            where TEntity : class, IEntity<int>;
+            where TEntity : class;
 
         /// <summary>
         /// Updates existing entry.
         /// </summary>
         /// <param name="entity">Entity object</param>
-        /// <typeparam name="TEntity">Class that implements the <see cref="IEntity{TKey}"/> interface</typeparam>
+        /// <typeparam name="TEntity">Entity type</typeparam>
         void Update<TEntity>(TEntity entity)
-            where TEntity : class, IEntity<int>;
+            where TEntity : class;
 
         /// <summary>
         /// Deletes entity object from database.
         /// </summary>
         /// <param name="entity">Entity object</param>
-        /// <typeparam name="TEntity">Class that implements the <see cref="IEntity{TKey}"/> interface</typeparam>
+        /// <typeparam name="TEntity">Entity type</typeparam>
         void Delete<TEntity>(TEntity? entity)
-            where TEntity : class, IEntity<int>;
+            where TEntity : class;
     }
 }

--- a/src/NavQurt.Server.Infrastructure/Data/MainDbContext.cs
+++ b/src/NavQurt.Server.Infrastructure/Data/MainDbContext.cs
@@ -1,4 +1,4 @@
-﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Identity.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore;
 using NavQurt.Server.Core.Entities;
@@ -12,7 +12,7 @@ namespace NavQurt.Server.Infrastructure.Data
         protected override void OnModelCreating(ModelBuilder b)
         {
             base.OnModelCreating(b);
-         
+
             b.Entity<IdentityRoleClaim<string>>().ToTable("RoleClaims");
             b.Entity<IdentityUserRole<string>>().ToTable("UserRoles");
             b.Entity<IdentityUserLogin<string>>().ToTable("UserLogins");
@@ -20,14 +20,13 @@ namespace NavQurt.Server.Infrastructure.Data
             b.Entity<IdentityUserToken<string>>().ToTable("UserTokens");
             b.Entity<AppUser>().ToTable("Users");
 
-
             b.Entity<OpenIdApplication>().ToTable("OpenIddictEntityFrameworkCoreApplications");
             b.Entity<OpenIdAuthorization>().ToTable("OpenIddictEntityFrameworkCoreAuthorizations");
             b.Entity<OpenIdScope>().ToTable("OpenIddictEntityFrameworkCoreScopes");
             b.Entity<OpenIdToken>().ToTable("OpenIddictEntityFrameworkCoreTokens");
 
             b.UseOpenIddict();
-            b.ApplyConfigurationsFromAssembly(typeof(AppDbContext).Assembly);
+            b.ApplyConfigurationsFromAssembly(typeof(MainDbContext).Assembly);
         }
     }
 }

--- a/src/NavQurt.Server.Infrastructure/Persistence/GenericRepository.cs
+++ b/src/NavQurt.Server.Infrastructure/Persistence/GenericRepository.cs
@@ -1,6 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore;
-using NavQurt.Server.Core.Entities;
+using Microsoft.EntityFrameworkCore;
 using NavQurt.Server.Core.Persistence;
+using System.Linq;
 using System.Linq.Expressions;
 
 namespace NavQurt.Server.Infrastructure.Persistence
@@ -21,16 +21,15 @@ namespace NavQurt.Server.Infrastructure.Persistence
         public IUnitOfWork UnitOfWork { get; }
 
         public Task<int> CountAsync<TEntity>(Expression<Func<TEntity, bool>>? predicate = default)
-            where TEntity : class, IEntity<int>
+            where TEntity : class
         {
             return predicate == default ? Context.Set<TEntity>().CountAsync()
                 : Context.Set<TEntity>().CountAsync(predicate);
         }
 
         public Task<decimal> SumAsync<TEntity>(Expression<Func<TEntity, decimal>> selector, Expression<Func<TEntity, bool>>? predicate = default)
-            where TEntity : class, IEntity<int>
+            where TEntity : class
         {
-
             return predicate == default ? Context.Set<TEntity>().SumAsync(selector) :
                 Context.Set<TEntity>().Where(predicate).SumAsync(selector);
         }
@@ -43,13 +42,13 @@ namespace NavQurt.Server.Infrastructure.Persistence
         }
 
         public Task<TEntity?> GetAsync<TEntity>(Expression<Func<TEntity, bool>> predicate)
-            where TEntity : class, IEntity<int>
+            where TEntity : class
         {
             return Context.Set<TEntity>().FirstOrDefaultAsync(predicate);
         }
 
         public Task<List<TEntity>> GetListAsync<TEntity>(Expression<Func<TEntity, bool>>? predicate = default)
-            where TEntity : class, IEntity<int>
+            where TEntity : class
         {
             return predicate == default ? Context.Set<TEntity>().ToListAsync()
                 : Context.Set<TEntity>().Where(predicate).ToListAsync();
@@ -58,7 +57,7 @@ namespace NavQurt.Server.Infrastructure.Persistence
         public Task<Dictionary<TKey, TEntity>> GetDictionaryAsync<TKey, TEntity>(
             Func<TEntity, TKey> keySelector,
             Expression<Func<TEntity, bool>>? predicate = default)
-            where TEntity : class, IEntity<int>
+            where TEntity : class
             where TKey : notnull
         {
             return predicate == default ? Context.Set<TEntity>().ToDictionaryAsync(keySelector)
@@ -74,20 +73,20 @@ namespace NavQurt.Server.Infrastructure.Persistence
         }
 
         public async Task AddAsync<TEntity>(TEntity entity)
-            where TEntity : class, IEntity<int>
+            where TEntity : class
         {
             await Context.Set<TEntity>().AddAsync(entity);
         }
 
         public void Update<TEntity>(TEntity entity)
-            where TEntity : class, IEntity<int>
+            where TEntity : class
         {
             Context.Set<TEntity>().Attach(entity);
             Context.Entry(entity).State = EntityState.Modified;
         }
 
         public void Delete<TEntity>(TEntity? entity)
-            where TEntity : class, IEntity<int>
+            where TEntity : class
         {
             if (entity == null)
                 return;

--- a/src/NavQurt.Server.Infrastructure/Seed/IdentitySeeder.cs
+++ b/src/NavQurt.Server.Infrastructure/Seed/IdentitySeeder.cs
@@ -1,7 +1,10 @@
-﻿using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Logging;
 using NavQurt.Server.Core.Entities;
 using OpenIddict.Abstractions;
+using System.Linq;
 
 namespace NavQurt.Server.Infrastructure.Seed
 {
@@ -10,35 +13,66 @@ namespace NavQurt.Server.Infrastructure.Seed
         public static async Task SeedAsync(IServiceProvider sp)
         {
             using var scope = sp.CreateScope();
-            var roleMgr = scope.ServiceProvider.GetRequiredService<RoleManager<AppRole>>();
-            var userMgr = scope.ServiceProvider.GetRequiredService<UserManager<AppUser>>();
-            var appMgr = scope.ServiceProvider.GetRequiredService<IOpenIddictApplicationManager>();
+            var services = scope.ServiceProvider;
+            var roleMgr = services.GetRequiredService<RoleManager<AppRole>>();
+            var userMgr = services.GetRequiredService<UserManager<AppUser>>();
+            var appMgr = services.GetRequiredService<IOpenIddictApplicationManager>();
+            var configuration = services.GetRequiredService<IConfiguration>();
+            var logger = services.GetRequiredService<ILogger<IdentitySeeder>>();
 
-            // Rollar
-            foreach (var r in new[] { "SuperAdmin", "Admin", "Customer" })
-                if (!await roleMgr.RoleExistsAsync(r))
-                    await roleMgr.CreateAsync(new AppRole { Name = r });
-
-            // Admin user (dev uchun)
-            var admin = await userMgr.FindByNameAsync("admin");
-            if (admin is null)
+            // Roles
+            foreach (var role in new[] { "SuperAdmin", "Admin", "Customer" })
             {
-                admin = new AppUser
+                if (!await roleMgr.RoleExistsAsync(role))
                 {
-                    UserName = "SuperAdmin",
-                    Email = "superadmin@qurt.local",
-                    EmailConfirmed = true,
-                    PhoneNumber = "+998900000000",
-                    PhoneNumberConfirmed = true,
-                    FirstName = "System",
-                    LastName = "SuperAdmin",
-                    IsActive = true
-                };
-                await userMgr.CreateAsync(admin, "SuperAdmin@123"); // dev parol
-                await userMgr.AddToRoleAsync(admin, "SuperAdmin");
+                    await roleMgr.CreateAsync(new AppRole { Name = role });
+                }
             }
 
-            // (Ixtiyoriy) Agar client ro‘yxatdan o‘tkazmoqchi bo‘lsangiz:
+            // Admin user (dev only)
+            var adminUserName = configuration["Seed:AdminUserName"] ?? "SuperAdmin";
+            var adminEmail = configuration["Seed:AdminEmail"] ?? "superadmin@qurt.local";
+            var adminPassword = configuration["Seed:AdminPassword"];
+
+            var admin = await userMgr.FindByNameAsync(adminUserName) ?? await userMgr.FindByEmailAsync(adminEmail);
+            if (admin is null)
+            {
+                if (string.IsNullOrWhiteSpace(adminPassword))
+                {
+                    logger.LogWarning("Seed:AdminPassword is not configured; skipping administrator account creation.");
+                }
+                else
+                {
+                    admin = new AppUser
+                    {
+                        UserName = adminUserName,
+                        Email = adminEmail,
+                        EmailConfirmed = true,
+                        PhoneNumber = configuration["Seed:AdminPhone"] ?? "+998900000000",
+                        PhoneNumberConfirmed = true,
+                        FirstName = configuration["Seed:AdminFirstName"] ?? "System",
+                        LastName = configuration["Seed:AdminLastName"] ?? "SuperAdmin",
+                        IsActive = true
+                    };
+
+                    var createResult = await userMgr.CreateAsync(admin, adminPassword);
+                    if (!createResult.Succeeded)
+                    {
+                        logger.LogError("Failed to create administrator account: {Errors}", string.Join(", ", createResult.Errors.Select(e => e.Description)));
+                        admin = null;
+                    }
+                }
+            }
+
+            if (admin is not null)
+            {
+                if (!await userMgr.IsInRoleAsync(admin, "SuperAdmin"))
+                {
+                    await userMgr.AddToRoleAsync(admin, "SuperAdmin");
+                }
+            }
+
+            // Optional: register OpenIddict client
             if (await appMgr.FindByClientIdAsync("qurt-super-admin") is null)
             {
                 await appMgr.CreateAsync(new OpenIddictApplicationDescriptor
@@ -46,14 +80,14 @@ namespace NavQurt.Server.Infrastructure.Seed
                     ClientId = "qurt-super-admin",
                     DisplayName = "Qurt Super Admin Panel",
                     Permissions =
-                {
-                    OpenIddictConstants.Permissions.Endpoints.Token,
-                    OpenIddictConstants.Permissions.GrantTypes.Password,
-                    OpenIddictConstants.Permissions.GrantTypes.RefreshToken,
-                    OpenIddictConstants.Permissions.Scopes.Profile,
-                    OpenIddictConstants.Scopes.OfflineAccess,
-                    "scp:api"
-                }
+                    {
+                        OpenIddictConstants.Permissions.Endpoints.Token,
+                        OpenIddictConstants.Permissions.GrantTypes.Password,
+                        OpenIddictConstants.Permissions.GrantTypes.RefreshToken,
+                        OpenIddictConstants.Permissions.Scopes.Profile,
+                        OpenIddictConstants.Scopes.OfflineAccess,
+                        "scp:api",
+                    }
                 });
             }
         }

--- a/src/NavQurt.Server.Web/Extensions/DbContextExtensions.cs
+++ b/src/NavQurt.Server.Web/Extensions/DbContextExtensions.cs
@@ -1,4 +1,6 @@
-﻿using Microsoft.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
 using NavQurt.Server.Infrastructure.Data;
 
 namespace NavQurt.Server.Web.Extensions
@@ -8,6 +10,10 @@ namespace NavQurt.Server.Web.Extensions
         public static IServiceCollection AddAppDbContext(this IServiceCollection services, IConfiguration configuration)
         {
             services.AddDbContext<MainDbContext>(options =>
+                options.UseNpgsql(configuration.GetConnectionString("Default"))
+            );
+
+            services.AddDbContext<AppDbContext>(options =>
                 options.UseNpgsql(configuration.GetConnectionString("Default"))
             );
 


### PR DESCRIPTION
## Summary
- align authentication DTOs and repository abstractions with Identity's string keys
- correct DbContext registration and configuration to support both identity and application stores
- secure the identity seeder and document the required configuration for local setup

## Testing
- not run (dotnet SDK unavailable in environment)


------
https://chatgpt.com/codex/tasks/task_e_68d6b3a83e8c8330b058cb714be24e80