### PR TITLE
Implement comprehensive auth and user management services

### DIFF
--- a/src/NavQurt.Server.Application/Dto/Auth.cs
+++ b/src/NavQurt.Server.Application/Dto/Auth.cs
@@ -1,6 +1,50 @@
-namespace NavQurt.Server.Application.Dto
-{
-    public record SignUpRequest(string UserName, string Password, string? FirstName, string? LastName, string? Email, string? Phone);
-    public record SignUpResponse(string UserId, string UserName, string? Email, string? Phone, string? FullName);
-    public record AssignRoleRequest(string UserId, string RoleName);
-}
+namespace NavQurt.Server.Application.Dto;
+
+public record SignUpRequest(
+    string UserName,
+    string Password,
+    string? FirstName,
+    string? LastName,
+    string? Email,
+    string? Phone);
+
+public record SignUpResponse(
+    string UserId,
+    string UserName,
+    string? Email,
+    string? Phone,
+    string? FullName,
+    IReadOnlyList<string> Roles);
+
+public record LoginRequest(string UserNameOrEmail, string Password, bool RememberMe);
+
+public record LoginResponse(
+    string UserId,
+    string UserName,
+    string? Email,
+    string? PhoneNumber,
+    bool EmailConfirmed,
+    bool PhoneNumberConfirmed,
+    bool IsActive,
+    IReadOnlyList<string> Roles,
+    bool RequiresTwoFactor);
+
+public record ForgotPasswordRequest(string Email);
+
+public record PasswordResetTokenResponse(string UserId, string Token);
+
+public record ResetPasswordRequest(string UserId, string Token, string NewPassword);
+
+public record ChangePasswordRequest(string UserId, string CurrentPassword, string NewPassword);
+
+public record GenerateEmailVerificationTokenRequest(string UserId);
+
+public record EmailVerificationTokenResponse(string UserId, string Token);
+
+public record EmailVerificationRequest(string UserId, string Token);
+
+public record GeneratePhoneNumberTokenRequest(string UserId, string? PhoneNumber);
+
+public record PhoneVerificationTokenResponse(string UserId, string PhoneNumber, string Token);
+
+public record VerifyPhoneNumberRequest(string UserId, string PhoneNumber, string Token);

--- a/src/NavQurt.Server.Application/Dto/OperationResult.cs
+++ b/src/NavQurt.Server.Application/Dto/OperationResult.cs
@@ -1,0 +1,62 @@
+using System.Linq;
+
+namespace NavQurt.Server.Application.Dto;
+
+public enum OperationStatus
+{
+    Success,
+    NotFound,
+    Invalid,
+    Conflict,
+    Forbidden,
+    Error
+}
+
+public class OperationResult<T>
+{
+    private OperationResult(OperationStatus status, T? data, IReadOnlyList<string> errors)
+    {
+        Status = status;
+        Data = data;
+        Errors = errors;
+    }
+
+    public OperationStatus Status { get; }
+
+    public bool Succeeded => Status == OperationStatus.Success;
+
+    public T? Data { get; }
+
+    public IReadOnlyList<string> Errors { get; }
+
+    public static OperationResult<T> Success(T data) =>
+        new(OperationStatus.Success, data, Array.Empty<string>());
+
+    public static OperationResult<T> NotFound(params string[] errors) =>
+        Failure(OperationStatus.NotFound, errors);
+
+    public static OperationResult<T> Invalid(params string[] errors) =>
+        Failure(OperationStatus.Invalid, errors);
+
+    public static OperationResult<T> Conflict(params string[] errors) =>
+        Failure(OperationStatus.Conflict, errors);
+
+    public static OperationResult<T> Forbidden(params string[] errors) =>
+        Failure(OperationStatus.Forbidden, errors);
+
+    public static OperationResult<T> Error(params string[] errors) =>
+        Failure(OperationStatus.Error, errors);
+
+    public static OperationResult<T> Failure(OperationStatus status, IEnumerable<string> errors) =>
+        new(status, default, NormalizeErrors(errors));
+
+    private static IReadOnlyList<string> NormalizeErrors(IEnumerable<string> errors)
+    {
+        if (errors is IReadOnlyList<string> readOnly)
+        {
+            return readOnly;
+        }
+
+        return errors?.Where(e => !string.IsNullOrWhiteSpace(e)).ToArray() ?? Array.Empty<string>();
+    }
+}

--- a/src/NavQurt.Server.Application/Dto/UserManagement.cs
+++ b/src/NavQurt.Server.Application/Dto/UserManagement.cs
@@ -1,0 +1,28 @@
+namespace NavQurt.Server.Application.Dto;
+
+public record UserDto(
+    string Id,
+    string UserName,
+    string? FirstName,
+    string? LastName,
+    string? Email,
+    bool EmailConfirmed,
+    string? PhoneNumber,
+    bool PhoneNumberConfirmed,
+    bool IsActive,
+    string? FullName,
+    DateTime CreatedAt,
+    IReadOnlyList<string> Roles);
+
+public record UpdateUserProfileRequest(
+    string? UserId,
+    string? UserName,
+    string? FirstName,
+    string? LastName,
+    string? Email,
+    string? PhoneNumber,
+    bool? IsActive);
+
+public record UpdateUserRolesRequest(string? UserId, IReadOnlyCollection<string> Roles);
+
+public record UpdateUserStatusRequest(string? UserId, bool IsActive);

--- a/src/NavQurt.Server.Application/Interfaces/IAuthService.cs
+++ b/src/NavQurt.Server.Application/Interfaces/IAuthService.cs
@@ -1,0 +1,24 @@
+using NavQurt.Server.Application.Dto;
+
+namespace NavQurt.Server.Application.Interfaces;
+
+public interface IAuthService
+{
+    Task<OperationResult<SignUpResponse>> SignUpAsync(SignUpRequest request, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<LoginResponse>> LoginAsync(LoginRequest request, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<bool>> ChangePasswordAsync(ChangePasswordRequest request, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<PasswordResetTokenResponse>> GeneratePasswordResetTokenAsync(ForgotPasswordRequest request, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<bool>> ResetPasswordAsync(ResetPasswordRequest request, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<EmailVerificationTokenResponse>> GenerateEmailVerificationTokenAsync(GenerateEmailVerificationTokenRequest request, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<bool>> ConfirmEmailAsync(EmailVerificationRequest request, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<PhoneVerificationTokenResponse>> GeneratePhoneNumberTokenAsync(GeneratePhoneNumberTokenRequest request, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<bool>> VerifyPhoneNumberAsync(VerifyPhoneNumberRequest request, CancellationToken cancellationToken = default);
+}

--- a/src/NavQurt.Server.Application/Interfaces/IUserService.cs
+++ b/src/NavQurt.Server.Application/Interfaces/IUserService.cs
@@ -1,0 +1,18 @@
+using NavQurt.Server.Application.Dto;
+
+namespace NavQurt.Server.Application.Interfaces;
+
+public interface IUserService
+{
+    Task<OperationResult<IReadOnlyList<UserDto>>> GetUsersAsync(CancellationToken cancellationToken = default);
+
+    Task<OperationResult<UserDto>> GetUserByIdAsync(string userId, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<UserDto>> UpdateUserProfileAsync(UpdateUserProfileRequest request, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<UserDto>> UpdateUserRolesAsync(UpdateUserRolesRequest request, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<UserDto>> SetUserActivationAsync(UpdateUserStatusRequest request, CancellationToken cancellationToken = default);
+
+    Task<OperationResult<bool>> DeleteUserAsync(string userId, CancellationToken cancellationToken = default);
+}

--- a/src/NavQurt.Server.Application/NavQurt.Server.Application.csproj
+++ b/src/NavQurt.Server.Application/NavQurt.Server.Application.csproj
@@ -15,4 +15,9 @@
     <Folder Include="Services\" />
   </ItemGroup>
 
+  <ItemGroup>
+    <FrameworkReference Include="Microsoft.AspNetCore.App" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="8.0.20" />
+  </ItemGroup>
+
 </Project>

--- a/src/NavQurt.Server.Application/Services/AuthService.cs
+++ b/src/NavQurt.Server.Application/Services/AuthService.cs
@@ -1,0 +1,258 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.Extensions.Logging;
+using System.Linq;
+using NavQurt.Server.Application.Dto;
+using NavQurt.Server.Application.Interfaces;
+using NavQurt.Server.Core.Entities;
+
+namespace NavQurt.Server.Application.Services;
+
+public class AuthService : IAuthService
+{
+    private readonly UserManager<AppUser> _userManager;
+    private readonly SignInManager<AppUser> _signInManager;
+    private readonly RoleManager<AppRole> _roleManager;
+    private readonly ILogger<AuthService> _logger;
+
+    public AuthService(
+        UserManager<AppUser> userManager,
+        SignInManager<AppUser> signInManager,
+        RoleManager<AppRole> roleManager,
+        ILogger<AuthService> logger)
+    {
+        _userManager = userManager;
+        _signInManager = signInManager;
+        _roleManager = roleManager;
+        _logger = logger;
+    }
+
+    public async Task<OperationResult<SignUpResponse>> SignUpAsync(SignUpRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.UserName))
+        {
+            return OperationResult<SignUpResponse>.Invalid("Username is required.");
+        }
+
+        if (string.IsNullOrWhiteSpace(request.Password))
+        {
+            return OperationResult<SignUpResponse>.Invalid("Password is required.");
+        }
+
+        var user = new AppUser
+        {
+            UserName = request.UserName,
+            Email = request.Email,
+            FirstName = request.FirstName,
+            LastName = request.LastName,
+            PhoneNumber = request.Phone,
+            IsActive = true
+        };
+
+        var createResult = await _userManager.CreateAsync(user, request.Password);
+        if (!createResult.Succeeded)
+        {
+            return OperationResult<SignUpResponse>.Invalid(createResult.Errors.Select(e => e.Description).ToArray());
+        }
+
+        if (await _roleManager.RoleExistsAsync("Customer"))
+        {
+            var roleResult = await _userManager.AddToRoleAsync(user, "Customer");
+            if (!roleResult.Succeeded)
+            {
+                _logger.LogWarning("Failed to assign default role to user {UserId}: {Errors}", user.Id, string.Join(", ", roleResult.Errors.Select(e => e.Description)));
+            }
+        }
+
+        var roles = await _userManager.GetRolesAsync(user);
+        var response = new SignUpResponse(user.Id, user.UserName!, user.Email, user.PhoneNumber, user.FullName, roles);
+
+        return OperationResult<SignUpResponse>.Success(response);
+    }
+
+    public async Task<OperationResult<LoginResponse>> LoginAsync(LoginRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.UserNameOrEmail))
+        {
+            return OperationResult<LoginResponse>.Invalid("Username or email is required.");
+        }
+
+        var user = await _userManager.FindByNameAsync(request.UserNameOrEmail);
+        user ??= await _userManager.FindByEmailAsync(request.UserNameOrEmail);
+
+        if (user is null)
+        {
+            return OperationResult<LoginResponse>.NotFound("User not found.");
+        }
+
+        if (!user.IsActive)
+        {
+            return OperationResult<LoginResponse>.Forbidden("User account is inactive.");
+        }
+
+        var signInResult = await _signInManager.CheckPasswordSignInAsync(user, request.Password, lockoutOnFailure: true);
+        if (signInResult.IsLockedOut)
+        {
+            return OperationResult<LoginResponse>.Forbidden("User account is locked out.");
+        }
+
+        if (signInResult.IsNotAllowed)
+        {
+            return OperationResult<LoginResponse>.Forbidden("User is not allowed to sign in.");
+        }
+
+        if (!signInResult.Succeeded)
+        {
+            return OperationResult<LoginResponse>.Invalid("Invalid username or password.");
+        }
+
+        var roles = await _userManager.GetRolesAsync(user);
+        var response = new LoginResponse(
+            user.Id,
+            user.UserName!,
+            user.Email,
+            user.PhoneNumber,
+            user.EmailConfirmed,
+            user.PhoneNumberConfirmed,
+            user.IsActive,
+            roles,
+            signInResult.RequiresTwoFactor);
+
+        return OperationResult<LoginResponse>.Success(response);
+    }
+
+    public async Task<OperationResult<bool>> ChangePasswordAsync(ChangePasswordRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            return OperationResult<bool>.NotFound("User not found.");
+        }
+
+        var result = await _userManager.ChangePasswordAsync(user, request.CurrentPassword, request.NewPassword);
+        if (!result.Succeeded)
+        {
+            return OperationResult<bool>.Invalid(result.Errors.Select(e => e.Description).ToArray());
+        }
+
+        return OperationResult<bool>.Success(true);
+    }
+
+    public async Task<OperationResult<PasswordResetTokenResponse>> GeneratePasswordResetTokenAsync(ForgotPasswordRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.Email))
+        {
+            return OperationResult<PasswordResetTokenResponse>.Invalid("Email is required.");
+        }
+
+        var user = await _userManager.FindByEmailAsync(request.Email);
+        if (user is null)
+        {
+            return OperationResult<PasswordResetTokenResponse>.NotFound("User not found.");
+        }
+
+        var token = await _userManager.GeneratePasswordResetTokenAsync(user);
+        var response = new PasswordResetTokenResponse(user.Id, token);
+
+        return OperationResult<PasswordResetTokenResponse>.Success(response);
+    }
+
+    public async Task<OperationResult<bool>> ResetPasswordAsync(ResetPasswordRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            return OperationResult<bool>.NotFound("User not found.");
+        }
+
+        var result = await _userManager.ResetPasswordAsync(user, request.Token, request.NewPassword);
+        if (!result.Succeeded)
+        {
+            return OperationResult<bool>.Invalid(result.Errors.Select(e => e.Description).ToArray());
+        }
+
+        return OperationResult<bool>.Success(true);
+    }
+
+    public async Task<OperationResult<EmailVerificationTokenResponse>> GenerateEmailVerificationTokenAsync(GenerateEmailVerificationTokenRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            return OperationResult<EmailVerificationTokenResponse>.NotFound("User not found.");
+        }
+
+        if (user.EmailConfirmed)
+        {
+            return OperationResult<EmailVerificationTokenResponse>.Conflict("Email is already confirmed.");
+        }
+
+        if (string.IsNullOrWhiteSpace(user.Email))
+        {
+            return OperationResult<EmailVerificationTokenResponse>.Invalid("User email is not set.");
+        }
+
+        var token = await _userManager.GenerateEmailConfirmationTokenAsync(user);
+        var response = new EmailVerificationTokenResponse(user.Id, token);
+
+        return OperationResult<EmailVerificationTokenResponse>.Success(response);
+    }
+
+    public async Task<OperationResult<bool>> ConfirmEmailAsync(EmailVerificationRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            return OperationResult<bool>.NotFound("User not found.");
+        }
+
+        if (user.EmailConfirmed)
+        {
+            return OperationResult<bool>.Success(true);
+        }
+
+        var result = await _userManager.ConfirmEmailAsync(user, request.Token);
+        if (!result.Succeeded)
+        {
+            return OperationResult<bool>.Invalid(result.Errors.Select(e => e.Description).ToArray());
+        }
+
+        return OperationResult<bool>.Success(true);
+    }
+
+    public async Task<OperationResult<PhoneVerificationTokenResponse>> GeneratePhoneNumberTokenAsync(GeneratePhoneNumberTokenRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            return OperationResult<PhoneVerificationTokenResponse>.NotFound("User not found.");
+        }
+
+        var phoneNumber = string.IsNullOrWhiteSpace(request.PhoneNumber) ? user.PhoneNumber : request.PhoneNumber;
+        if (string.IsNullOrWhiteSpace(phoneNumber))
+        {
+            return OperationResult<PhoneVerificationTokenResponse>.Invalid("Phone number is required.");
+        }
+
+        var token = await _userManager.GenerateChangePhoneNumberTokenAsync(user, phoneNumber);
+        var response = new PhoneVerificationTokenResponse(user.Id, phoneNumber, token);
+
+        return OperationResult<PhoneVerificationTokenResponse>.Success(response);
+    }
+
+    public async Task<OperationResult<bool>> VerifyPhoneNumberAsync(VerifyPhoneNumberRequest request, CancellationToken cancellationToken = default)
+    {
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            return OperationResult<bool>.NotFound("User not found.");
+        }
+
+        var result = await _userManager.ChangePhoneNumberAsync(user, request.PhoneNumber, request.Token);
+        if (!result.Succeeded)
+        {
+            return OperationResult<bool>.Invalid(result.Errors.Select(e => e.Description).ToArray());
+        }
+
+        return OperationResult<bool>.Success(true);
+    }
+}

--- a/src/NavQurt.Server.Application/Services/UserService.cs
+++ b/src/NavQurt.Server.Application/Services/UserService.cs
@@ -1,0 +1,220 @@
+using Microsoft.AspNetCore.Identity;
+using Microsoft.EntityFrameworkCore;
+using System.Linq;
+using NavQurt.Server.Application.Dto;
+using NavQurt.Server.Application.Interfaces;
+using NavQurt.Server.Core.Entities;
+
+namespace NavQurt.Server.Application.Services;
+
+public class UserService : IUserService
+{
+    private readonly UserManager<AppUser> _userManager;
+    private readonly RoleManager<AppRole> _roleManager;
+
+    public UserService(UserManager<AppUser> userManager, RoleManager<AppRole> roleManager)
+    {
+        _userManager = userManager;
+        _roleManager = roleManager;
+    }
+
+    public async Task<OperationResult<IReadOnlyList<UserDto>>> GetUsersAsync(CancellationToken cancellationToken = default)
+    {
+        var users = await _userManager.Users
+            .OrderBy(u => u.UserName)
+            .ToListAsync(cancellationToken);
+
+        var dtos = new List<UserDto>(users.Count);
+        foreach (var user in users)
+        {
+            var roles = await _userManager.GetRolesAsync(user);
+            dtos.Add(ToDto(user, roles));
+        }
+
+        return OperationResult<IReadOnlyList<UserDto>>.Success(dtos);
+    }
+
+    public async Task<OperationResult<UserDto>> GetUserByIdAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        var user = await _userManager.Users.FirstOrDefaultAsync(u => u.Id == userId, cancellationToken);
+        if (user is null)
+        {
+            return OperationResult<UserDto>.NotFound("User not found.");
+        }
+
+        var roles = await _userManager.GetRolesAsync(user);
+        return OperationResult<UserDto>.Success(ToDto(user, roles));
+    }
+
+    public async Task<OperationResult<UserDto>> UpdateUserProfileAsync(UpdateUserProfileRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.UserId))
+        {
+            return OperationResult<UserDto>.Invalid("User id is required.");
+        }
+
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            return OperationResult<UserDto>.NotFound("User not found.");
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.UserName) && !string.Equals(user.UserName, request.UserName, StringComparison.OrdinalIgnoreCase))
+        {
+            var usernameResult = await _userManager.SetUserNameAsync(user, request.UserName);
+            if (!usernameResult.Succeeded)
+            {
+                return OperationResult<UserDto>.Invalid(usernameResult.Errors.Select(e => e.Description).ToArray());
+            }
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.Email) && !string.Equals(user.Email, request.Email, StringComparison.OrdinalIgnoreCase))
+        {
+            var emailResult = await _userManager.SetEmailAsync(user, request.Email);
+            if (!emailResult.Succeeded)
+            {
+                return OperationResult<UserDto>.Invalid(emailResult.Errors.Select(e => e.Description).ToArray());
+            }
+
+            user.EmailConfirmed = false;
+        }
+
+        if (!string.IsNullOrWhiteSpace(request.PhoneNumber))
+        {
+            var phoneResult = await _userManager.SetPhoneNumberAsync(user, request.PhoneNumber);
+            if (!phoneResult.Succeeded)
+            {
+                return OperationResult<UserDto>.Invalid(phoneResult.Errors.Select(e => e.Description).ToArray());
+            }
+        }
+
+        if (request.FirstName is not null)
+        {
+            user.FirstName = request.FirstName;
+        }
+
+        if (request.LastName is not null)
+        {
+            user.LastName = request.LastName;
+        }
+
+        if (request.IsActive.HasValue)
+        {
+            user.IsActive = request.IsActive.Value;
+        }
+
+        var updateResult = await _userManager.UpdateAsync(user);
+        if (!updateResult.Succeeded)
+        {
+            return OperationResult<UserDto>.Invalid(updateResult.Errors.Select(e => e.Description).ToArray());
+        }
+
+        var roles = await _userManager.GetRolesAsync(user);
+        return OperationResult<UserDto>.Success(ToDto(user, roles));
+    }
+
+    public async Task<OperationResult<UserDto>> UpdateUserRolesAsync(UpdateUserRolesRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.UserId))
+        {
+            return OperationResult<UserDto>.Invalid("User id is required.");
+        }
+
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            return OperationResult<UserDto>.NotFound("User not found.");
+        }
+
+        var targetRoles = request.Roles?.Where(r => !string.IsNullOrWhiteSpace(r)).Select(r => r.Trim()).Distinct(StringComparer.OrdinalIgnoreCase).ToArray() ?? Array.Empty<string>();
+        foreach (var role in targetRoles)
+        {
+            if (!await _roleManager.RoleExistsAsync(role))
+            {
+                return OperationResult<UserDto>.Invalid($"Role '{role}' does not exist.");
+            }
+        }
+
+        var currentRoles = await _userManager.GetRolesAsync(user);
+        var rolesToRemove = currentRoles.Except(targetRoles, StringComparer.OrdinalIgnoreCase).ToArray();
+        if (rolesToRemove.Length > 0)
+        {
+            var removeResult = await _userManager.RemoveFromRolesAsync(user, rolesToRemove);
+            if (!removeResult.Succeeded)
+            {
+                return OperationResult<UserDto>.Invalid(removeResult.Errors.Select(e => e.Description).ToArray());
+            }
+        }
+
+        var rolesToAdd = targetRoles.Except(currentRoles, StringComparer.OrdinalIgnoreCase).ToArray();
+        if (rolesToAdd.Length > 0)
+        {
+            var addResult = await _userManager.AddToRolesAsync(user, rolesToAdd);
+            if (!addResult.Succeeded)
+            {
+                return OperationResult<UserDto>.Invalid(addResult.Errors.Select(e => e.Description).ToArray());
+            }
+        }
+
+        var updatedRoles = await _userManager.GetRolesAsync(user);
+        return OperationResult<UserDto>.Success(ToDto(user, updatedRoles));
+    }
+
+    public async Task<OperationResult<UserDto>> SetUserActivationAsync(UpdateUserStatusRequest request, CancellationToken cancellationToken = default)
+    {
+        if (string.IsNullOrWhiteSpace(request.UserId))
+        {
+            return OperationResult<UserDto>.Invalid("User id is required.");
+        }
+
+        var user = await _userManager.FindByIdAsync(request.UserId);
+        if (user is null)
+        {
+            return OperationResult<UserDto>.NotFound("User not found.");
+        }
+
+        user.IsActive = request.IsActive;
+        var updateResult = await _userManager.UpdateAsync(user);
+        if (!updateResult.Succeeded)
+        {
+            return OperationResult<UserDto>.Invalid(updateResult.Errors.Select(e => e.Description).ToArray());
+        }
+
+        var roles = await _userManager.GetRolesAsync(user);
+        return OperationResult<UserDto>.Success(ToDto(user, roles));
+    }
+
+    public async Task<OperationResult<bool>> DeleteUserAsync(string userId, CancellationToken cancellationToken = default)
+    {
+        var user = await _userManager.FindByIdAsync(userId);
+        if (user is null)
+        {
+            return OperationResult<bool>.NotFound("User not found.");
+        }
+
+        var deleteResult = await _userManager.DeleteAsync(user);
+        if (!deleteResult.Succeeded)
+        {
+            return OperationResult<bool>.Invalid(deleteResult.Errors.Select(e => e.Description).ToArray());
+        }
+
+        return OperationResult<bool>.Success(true);
+    }
+
+    private static UserDto ToDto(AppUser user, IReadOnlyCollection<string> roles)
+    {
+        return new UserDto(
+            user.Id,
+            user.UserName ?? string.Empty,
+            user.FirstName,
+            user.LastName,
+            user.Email,
+            user.EmailConfirmed,
+            user.PhoneNumber,
+            user.PhoneNumberConfirmed,
+            user.IsActive,
+            user.FullName,
+            user.CreatedAt,
+            roles.ToList());
+    }
+}

--- a/src/NavQurt.Server.Web/Controllers/AuthController.cs
+++ b/src/NavQurt.Server.Web/Controllers/AuthController.cs
@@ -1,11 +1,185 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NavQurt.Server.Application.Dto;
+using NavQurt.Server.Application.Interfaces;
+using System.Security.Claims;
 
-namespace NavQurt.Server.Web.Controllers
+namespace NavQurt.Server.Web.Controllers;
+
+[ApiController]
+[Route("api/v1/auth")]
+public class AuthController : ControllerBase
 {
-    [ApiController]
-    [Route("api/v1/auth")]
-    public class AuthController : ControllerBase
-    {
+    private readonly IAuthService _authService;
 
+    public AuthController(IAuthService authService)
+    {
+        _authService = authService;
+    }
+
+    [HttpPost("sign-up")]
+    [AllowAnonymous]
+    public async Task<IActionResult> SignUp([FromBody] SignUpRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        var result = await _authService.SignUpAsync(request, cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpPost("login")]
+    [AllowAnonymous]
+    public async Task<IActionResult> Login([FromBody] LoginRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        var result = await _authService.LoginAsync(request, cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpPost("forgot-password")]
+    [AllowAnonymous]
+    public async Task<IActionResult> ForgotPassword([FromBody] ForgotPasswordRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        var result = await _authService.GeneratePasswordResetTokenAsync(request, cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpPost("reset-password")]
+    [AllowAnonymous]
+    public async Task<IActionResult> ResetPassword([FromBody] ResetPasswordRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        var result = await _authService.ResetPasswordAsync(request, cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpPost("change-password")]
+    [Authorize]
+    public async Task<IActionResult> ChangePassword([FromBody] ChangePasswordRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        if (!IsSameUserOrAdmin(request.UserId))
+        {
+            return Forbid();
+        }
+
+        var result = await _authService.ChangePasswordAsync(request, cancellationToken);
+        return MapResult(result, _ => NoContent());
+    }
+
+    [HttpPost("email/token")]
+    [Authorize]
+    public async Task<IActionResult> GenerateEmailToken([FromBody] GenerateEmailVerificationTokenRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        if (!IsSameUserOrAdmin(request.UserId))
+        {
+            return Forbid();
+        }
+
+        var result = await _authService.GenerateEmailVerificationTokenAsync(request, cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpPost("email/verify")]
+    [AllowAnonymous]
+    public async Task<IActionResult> VerifyEmail([FromBody] EmailVerificationRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        var result = await _authService.ConfirmEmailAsync(request, cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpPost("phone/token")]
+    [Authorize]
+    public async Task<IActionResult> GeneratePhoneToken([FromBody] GeneratePhoneNumberTokenRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        if (!IsSameUserOrAdmin(request.UserId))
+        {
+            return Forbid();
+        }
+
+        var result = await _authService.GeneratePhoneNumberTokenAsync(request, cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpPost("phone/verify")]
+    [AllowAnonymous]
+    public async Task<IActionResult> VerifyPhone([FromBody] VerifyPhoneNumberRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        var result = await _authService.VerifyPhoneNumberAsync(request, cancellationToken);
+        return MapResult(result);
+    }
+
+    private IActionResult MapResult<T>(OperationResult<T> result, Func<T?, IActionResult>? successFactory = null)
+    {
+        if (result.Succeeded)
+        {
+            return successFactory?.Invoke(result.Data) ?? Ok(result.Data);
+        }
+
+        return result.Status switch
+        {
+            OperationStatus.NotFound => NotFound(new { errors = result.Errors }),
+            OperationStatus.Conflict => Conflict(new { errors = result.Errors }),
+            OperationStatus.Forbidden => Forbid(),
+            OperationStatus.Error => StatusCode(StatusCodes.Status500InternalServerError, new { errors = result.Errors }),
+            _ => BadRequest(new { errors = result.Errors })
+        };
+    }
+
+    private bool IsSameUserOrAdmin(string? userId)
+    {
+        if (string.IsNullOrWhiteSpace(userId))
+        {
+            return false;
+        }
+
+        if (User.IsInRole("Admin") || User.IsInRole("SuperAdmin"))
+        {
+            return true;
+        }
+
+        var currentUserId = User.FindFirstValue(ClaimTypes.NameIdentifier);
+        return string.Equals(currentUserId, userId, StringComparison.Ordinal);
     }
 }

--- a/src/NavQurt.Server.Web/Controllers/UsersController.cs
+++ b/src/NavQurt.Server.Web/Controllers/UsersController.cs
@@ -1,11 +1,97 @@
-﻿using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Authorization;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Mvc;
+using NavQurt.Server.Application.Dto;
+using NavQurt.Server.Application.Interfaces;
 
-namespace NavQurt.Server.Web.Controllers
+namespace NavQurt.Server.Web.Controllers;
+
+[ApiController]
+[Route("api/v1/users")]
+[Authorize(Roles = "Admin,SuperAdmin")]
+public class UsersController : ControllerBase
 {
-    [ApiController]
-    [Route("api/v1")]
-    public class UsersController : ControllerBase
-    {
+    private readonly IUserService _userService;
 
+    public UsersController(IUserService userService)
+    {
+        _userService = userService;
+    }
+
+    [HttpGet]
+    public async Task<IActionResult> GetUsers(CancellationToken cancellationToken)
+    {
+        var result = await _userService.GetUsersAsync(cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpGet("{id}")]
+    public async Task<IActionResult> GetUserById(string id, CancellationToken cancellationToken)
+    {
+        var result = await _userService.GetUserByIdAsync(id, cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpPut("{id}")]
+    public async Task<IActionResult> UpdateUser(string id, [FromBody] UpdateUserProfileRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        var payload = request with { UserId = id };
+        var result = await _userService.UpdateUserProfileAsync(payload, cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpPut("{id}/roles")]
+    public async Task<IActionResult> UpdateUserRoles(string id, [FromBody] UpdateUserRolesRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        var payload = request with { UserId = id };
+        var result = await _userService.UpdateUserRolesAsync(payload, cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpPut("{id}/status")]
+    public async Task<IActionResult> SetUserStatus(string id, [FromBody] UpdateUserStatusRequest request, CancellationToken cancellationToken)
+    {
+        if (request is null)
+        {
+            return BadRequest(new { errors = new[] { "Request body is required." } });
+        }
+
+        var payload = request with { UserId = id };
+        var result = await _userService.SetUserActivationAsync(payload, cancellationToken);
+        return MapResult(result);
+    }
+
+    [HttpDelete("{id}")]
+    public async Task<IActionResult> DeleteUser(string id, CancellationToken cancellationToken)
+    {
+        var result = await _userService.DeleteUserAsync(id, cancellationToken);
+        return MapResult(result, _ => NoContent());
+    }
+
+    private IActionResult MapResult<T>(OperationResult<T> result, Func<T?, IActionResult>? successFactory = null)
+    {
+        if (result.Succeeded)
+        {
+            return successFactory?.Invoke(result.Data) ?? Ok(result.Data);
+        }
+
+        return result.Status switch
+        {
+            OperationStatus.NotFound => NotFound(new { errors = result.Errors }),
+            OperationStatus.Conflict => Conflict(new { errors = result.Errors }),
+            OperationStatus.Forbidden => Forbid(),
+            OperationStatus.Error => StatusCode(StatusCodes.Status500InternalServerError, new { errors = result.Errors }),
+            _ => BadRequest(new { errors = result.Errors })
+        };
     }
 }

--- a/src/NavQurt.Server.Web/Program.cs
+++ b/src/NavQurt.Server.Web/Program.cs
@@ -1,5 +1,7 @@
 using Microsoft.AspNetCore.Identity;
 using Microsoft.EntityFrameworkCore;
+using NavQurt.Server.Application.Interfaces;
+using NavQurt.Server.Application.Services;
 using NavQurt.Server.Core.Entities;
 using NavQurt.Server.Infrastructure.Data;
 using NavQurt.Server.Infrastructure.Seed;
@@ -23,6 +25,8 @@ namespace NavQurt.Server.Web
             builder.Services.AddAppOpenIddict();
             builder.Services.AddAppAuthentication();
             builder.Services.AddAppSwagger();
+            builder.Services.AddScoped<IAuthService, AuthService>();
+            builder.Services.AddScoped<IUserService, UserService>();
 
             var app = builder.Build();
 


### PR DESCRIPTION
## Summary
- add DTOs and operation result types to support auth and user flows
- implement Identity-based auth and user management services in the application layer
- expose REST endpoints for auth and administrative user management and register the services for DI

## Testing
- dotnet build *(fails: `dotnet` command not available in container)*

------
https://chatgpt.com/codex/tasks/task_e_68d6bb1b4c608330abcf7f494ed58c04